### PR TITLE
Clean up UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,15 +61,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "argus_macro"
-version = "0.0.1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/ide/packages/panoptes/src/File.tsx
+++ b/ide/packages/panoptes/src/File.tsx
@@ -117,7 +117,6 @@ const ObligationCard = ({
   range: CharRange;
   obligation: Obligation;
 }) => {
-  const [isInfoVisible, setIsInfoVisible] = useState(false);
   const file = useContext(FileContext)!;
   const id = obligationCardId(file, obligation.hash);
 
@@ -126,36 +125,22 @@ const ObligationCard = ({
     file
   );
 
-  const handleClick = () => {
-    setIsInfoVisible(!isInfoVisible);
-  };
-
-  const cname = classNames("ObligationCard", obligation.result);
+  const header = (
+    <span id={id} onMouseEnter={addHighlight} onMouseLeave={removeHighlight}>
+      <span className={classNames("result", obligation.result)}>
+        <ObligationResult result={obligation.result} />
+      </span>{" "}
+      <PrintObligation obligation={obligation} />
+    </span>
+  );
 
   return (
-    <div
-      id={id}
-      className={cname}
-      onMouseEnter={addHighlight}
-      onMouseLeave={removeHighlight}
-    >
-      <div className="PrettyObligationArea">
-        <span className={classNames("result", obligation.result)}>
-          <ObligationResult result={obligation.result} />
-        </span>{" "}
-        <PrintObligation obligation={obligation} />
-      </div>
-      <VSCodeButton
-        className="ObligationButton"
-        appearance="secondary"
-        onClick={handleClick}
-      >
-        {isInfoVisible ? <IcoChevronUp /> : <IcoChevronDown />}
-      </VSCodeButton>
-      {isInfoVisible && (
+    <CollapsibleElement
+      info={header}
+      Children={() => (
         <ObligationTreeWrapper range={range} obligation={obligation} />
       )}
-    </div>
+    />
   );
 };
 
@@ -244,14 +229,10 @@ const InExpr = ({ idx }: { idx: ExprIdx }) => {
     );
 
   // TODO: we should limit the length of the expression snippet.
-  const header = (
-    <span>
-      Expression <code>{expr.snippet}</code>
-    </span>
-  );
+  const header = <code>{expr.snippet}</code>;
   return (
     <div onMouseEnter={addHighlight} onMouseLeave={removeHighlight}>
-      <CollapsibleElement info={header}>{content}</CollapsibleElement>
+      <CollapsibleElement info={header} Children={() => content} />
     </div>
   );
 };
@@ -277,11 +258,12 @@ const ObligationBody = ({ bodyInfo }: { bodyInfo: BodyInfo }) => {
 
   return (
     <BodyInfoContext.Provider value={bodyInfo}>
-      <CollapsibleElement info={header}>
-        {_.map(bodyInfo.exprs, (i, idx) => (
-          <InExpr idx={i} key={idx} />
-        ))}
-      </CollapsibleElement>
+      <CollapsibleElement
+        info={header}
+        Children={() =>
+          _.map(bodyInfo.exprs, (i, idx) => <InExpr idx={i} key={idx} />)
+        }
+      />
     </BodyInfoContext.Provider>
   );
 };

--- a/ide/packages/panoptes/src/HoverInfo.tsx
+++ b/ide/packages/panoptes/src/HoverInfo.tsx
@@ -1,4 +1,5 @@
 import {
+  FloatingDelayGroup,
   FloatingPortal,
   offset,
   useFloating,
@@ -20,7 +21,11 @@ export const HoverInfo = ({
     onOpenChange: setIsOpen,
     middleware: [offset(() => 5)],
   });
-  const hover = useHover(context);
+  const hover = useHover(context, {
+    delay: {
+      open: 500,
+    },
+  });
   const { getReferenceProps, getFloatingProps } = useInteractions([hover]);
 
   return (

--- a/ide/packages/panoptes/src/Icons.css
+++ b/ide/packages/panoptes/src/Icons.css
@@ -1,0 +1,4 @@
+.codicon {
+  position: relative;
+  top: 0.2em;
+}

--- a/ide/packages/panoptes/src/Icons.tsx
+++ b/ide/packages/panoptes/src/Icons.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 
+import "./Icons.css";
+
 export const IcoPlus = () => <i className="codicon codicon-plus" />;
 
 export const IcoDot = () => (

--- a/ide/packages/panoptes/src/Toggle.css
+++ b/ide/packages/panoptes/src/Toggle.css
@@ -1,0 +1,14 @@
+.toggle-box {
+  display: inline;  
+  border: 1px solid var(--vscode-textCodeBlock-background);
+  border-radius: 4px;
+}
+
+.toggle-box.expanded {
+  display: inline-block;
+}
+
+.toggle-box .summary {
+  color: var(--vscode-input-placeholderForeground);
+  font-size: 80%;
+}

--- a/ide/packages/panoptes/src/Toggle.tsx
+++ b/ide/packages/panoptes/src/Toggle.tsx
@@ -1,0 +1,25 @@
+import classNames from "classnames";
+import React, { useState } from "react";
+
+import "./Toggle.css";
+
+export let Toggle = ({
+  Children,
+  summary,
+}: {
+  summary: React.ReactNode;
+  Children: React.FC;
+}) => {
+  let [expanded, setExpanded] = useState(false);
+  return (
+    <div
+      className={classNames("toggle-box", { expanded })}
+      onClick={e => {
+        e.stopPropagation();
+        setExpanded(!expanded);
+      }}
+    >
+      {expanded ? <Children /> : <span className="summary">{summary}</span>}
+    </div>
+  );
+};

--- a/ide/packages/panoptes/src/TreeView/Directory.css
+++ b/ide/packages/panoptes/src/TreeView/Directory.css
@@ -3,11 +3,15 @@
 }
 
 .DirRecursive.is-candidate {
-    border-left: 1px dotted #ccc;
+    border-left: 1px dotted var(--vscode-dropdown-border);
 }
 
 .DirRecursive.is-subgoal {
-    border-left: 1.5px solid #aaa;
+    border-left: 1.5px solid var(--vscode-descriptionForeground);
+}
+
+.DirRecursive.generic-edge {
+    border-left: 1px solid var(--vscode-widget-border);
 }
 
 .Collapsible {
@@ -15,7 +19,7 @@
 }
 
 .Collapsible.indent {
-    padding-left: 1em;
+    padding-left: 0.5em;
 }
 
 .Collapsible.collapsed {
@@ -29,11 +33,11 @@
 
 .DirNode > .toggle {
     display: inline-block;
-    width: 12px;
+    width: 10px;
 }
 
 .DirNode > .toggle > .codicon {
-    font-size: 12px;
+    font-size: 10px;
 }
 
 .information::before {

--- a/ide/packages/panoptes/src/Workspace.tsx
+++ b/ide/packages/panoptes/src/Workspace.tsx
@@ -19,21 +19,19 @@ function basename(path: string) {
   return path.split("/").reverse()[0];
 }
 
-const FatalErrorPanel = ({ error, resetErrorBoundary }: any) => {
-  return (
-    <div>
-      <p>
-        Whoops! This is not a drill, a fatal error occurred. Please{" "}
-        <a href="https://github.com/gavinleroy/argus/issues/new">
-          report this error
-        </a>{" "}
-        to the Argus team, and include the following information:
-      </p>
-      <pre>{error.message}</pre>
-      <button onClick={resetErrorBoundary}>Reset Argus</button>
-    </div>
-  );
-};
+const FatalErrorPanel = ({ error, resetErrorBoundary }: any) => (
+  <div>
+    <p>
+      Whoops! This is not a drill, a fatal error occurred. Please{" "}
+      <a href="https://github.com/gavinleroy/argus/issues/new">
+        report this error
+      </a>{" "}
+      to the Argus team, and include the following information:
+    </p>
+    <pre>{error.message}</pre>
+    <button onClick={resetErrorBoundary}>Reset Argus</button>
+  </div>
+);
 
 const Workspace = ({
   files,
@@ -41,31 +39,29 @@ const Workspace = ({
 }: {
   files: [Filename, ObligationsInBody[]][];
   reset: () => void;
-}) => {
-  return (
-    <VSCodePanels>
-      {_.map(files, ([filename, _], idx) => {
-        return (
-          <VSCodePanelTab key={idx} id={`tab-${idx}`}>
-            {basename(filename)}
-          </VSCodePanelTab>
-        );
-      })}
-      {_.map(files, ([filename, content], idx) => {
-        return (
-          <ErrorBoundary
-            key={idx}
-            FallbackComponent={FatalErrorPanel}
-            onReset={reset}
-          >
-            <VSCodePanelView key={idx} id={`view-${idx}`}>
-              <File file={filename} osibs={content} />
-            </VSCodePanelView>
-          </ErrorBoundary>
-        );
-      })}
-    </VSCodePanels>
-  );
-};
+}) => (
+  <VSCodePanels>
+    {_.map(files, ([filename, _], idx) => (
+      <VSCodePanelTab key={idx} id={`tab-${idx}`}>
+        {basename(filename)}
+      </VSCodePanelTab>
+    ))}
+    {_.map(files, ([filename, content], idx) => (
+      <ErrorBoundary
+        key={idx}
+        FallbackComponent={FatalErrorPanel}
+        onReset={reset}
+      >
+        <VSCodePanelView
+          key={idx}
+          id={`view-${idx}`}
+          style={{ paddingLeft: 0, paddingRight: 0 }}
+        >
+          <File file={filename} osibs={content} />
+        </VSCodePanelView>
+      </ErrorBoundary>
+    ))}
+  </VSCodePanels>
+);
 
 export default Workspace;

--- a/ide/packages/panoptes/src/main.tsx
+++ b/ide/packages/panoptes/src/main.tsx
@@ -1,7 +1,7 @@
 import { ObligationOutput } from "@argus/common/lib";
 import { Filename } from "@argus/common/lib";
 import * as React from "react";
-import * as ReactDOM from "react-dom";
+import * as ReactDOM from "react-dom/client";
 
 import App from "./App";
 
@@ -13,10 +13,6 @@ declare global {
 
 window.addEventListener("load", () => {
   console.log("Loading initialData", window.initialData);
-  ReactDOM.render(
-    <React.StrictMode>
-      <App initialData={window.initialData} />
-    </React.StrictMode>,
-    document.getElementById("root") as HTMLElement
-  );
+  let root = ReactDOM.createRoot(document.getElementById("root")!);
+  root.render(<App initialData={window.initialData} />);
 });

--- a/ide/packages/panoptes/src/print/print.tsx
+++ b/ide/packages/panoptes/src/print/print.tsx
@@ -101,7 +101,7 @@ export const PrintGoal = ({ o }: { o: Goal }) => {
   const Content = () => (
     <>
       <UnsafePrintGoalPredicate o={o.goal} />
-      <div style={{ opacity: 0.5 }}>RustcPretty: {o.debugComparison}</div>
+      {/*<div style={{ opacity: 0.5 }}>RustcPretty: {o.debugComparison}</div>*/}
     </>
   );
   return <PrintWithFallback object={o} Content={Content} />;

--- a/ide/packages/panoptes/src/print/private/path.jsx
+++ b/ide/packages/panoptes/src/print/private/path.jsx
@@ -3,7 +3,7 @@ import React from "react";
 
 import { HoverInfo } from "../../HoverInfo";
 import { takeRightUntil } from "../../utilities/func";
-import { Angled, CommaSeparated } from "./syntax";
+import { Angled, CommaSeparated, Kw } from "./syntax";
 import { PrintGenericArg, PrintTy } from "./ty";
 
 export const PrintValuePath = ({ o }) => {
@@ -145,12 +145,12 @@ export const PrintImplFor = ({ o }) => {
     ) : (
       <span>
         <PrintDefPathFull o={o.path} />
-        for
+        <Kw>for</Kw>
       </span>
     );
   return (
     <span>
-      impl {path} <PrintTy o={o.ty} />
+      <Kw>impl</Kw> {path} <PrintTy o={o.ty} />
     </span>
   );
 };
@@ -158,14 +158,12 @@ export const PrintImplFor = ({ o }) => {
 // <TY as PATH>
 export const PrintImplAs = ({ o }) => {
   const path =
-    o.path === undefined ? (
-      ""
-    ) : (
+    o.path !== undefined ? (
       <span>
-        {" as "}
-        <PrintDefPathFull o={o.path} />
+        {" "}
+        <Kw>as</Kw> <PrintDefPathFull o={o.path} />
       </span>
-    );
+    ) : null;
   return (
     <span>
       <PrintTy o={o.ty} />

--- a/ide/packages/panoptes/src/print/private/syntax.tsx
+++ b/ide/packages/panoptes/src/print/private/syntax.tsx
@@ -10,11 +10,11 @@ export const UnderscoreLifetime: Ident = { name: "'_" };
 
 export const PathRoot: Ident = { name: "{{root}}" };
 
-export const Kw = ({ children }: React.PropsWithChildren<{}>) => {
+export const Kw = ({ children }: React.PropsWithChildren) => {
   return <span className="kw">{children}</span>;
 };
 
-export const Angled = ({ children }: React.PropsWithChildren<{}>) => {
+export const Angled = ({ children }: React.PropsWithChildren) => {
   return (
     <span>
       {"<"}
@@ -24,7 +24,7 @@ export const Angled = ({ children }: React.PropsWithChildren<{}>) => {
   );
 };
 
-export const DBraced = ({ children }: React.PropsWithChildren<{}>) => {
+export const DBraced = ({ children }: React.PropsWithChildren) => {
   return (
     <span>
       {"{{"}


### PR DESCRIPTION
Just some small tweaks to make the UI more compact. Most notably, I added a `Toggle` component (needs a better name) that shows details on click. This is used for FunctionDef type signatures, impl block <quantifiers>, and impl block where clauses.

Some notes:
- I converted some components to take `React.FC` instead of `React.ReactNode[]` so they only lazily construct UI fragments when they're actually rendered. (Note: I think this causes a UI issue where collapsing a node and opening the node resets the collapse/open state for its entire subtree, which is not desirable.)
- Need to make sure that *every* color is defined in terms of vscode CSS variables. Ensure that the UI looks good under at least light and dark mode.
- React style thing: rather than returning the empty string `""` for "component that should render nothing", the idiomatic thing is to return `null`.
- The Argus workspace is fine for Argus devs (us) and maybe advanced Argus users. But we need a UI path that shows nothing except a single TreeApp when a user selects a particular failed obligation in the editor. Everything else (including the JSON tab) should be hidden by default. 